### PR TITLE
[minor] naming / url fixes

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -4,7 +4,7 @@ For each each plugin, as identified by a search for `pytest-*` on PyPI, we
 download, install and execute its tests using [tox](https://tox.readthedocs.io/en/latest/).
 If a plugin doesn't have a `tox.ini` file, we generate a simple
 `tox.ini` which just ensures that the plugin was installed successfully by
-running `py.test --help`.
+running `pytest --help`.
 
 Once we have tested all plugins, the results are posted to a web application
 that can be used to visualize them.
@@ -22,7 +22,7 @@ script.
 
 The main job of this script is to run `update_index.py`, which is reponsible for querying `pypi` and updating
 `index.txt` with latest pytest plugin information. This file is then pushed back to GitHub which will trigger a new [travis](https://travis-ci.org) build.
-  
+
 
 ## Details ##
 
@@ -40,7 +40,7 @@ like this:
   {
     "version": "1.3.7",
     "name": "pytest-allure-adaptor",
-    "description": "Plugin for py.test to generate allure xml reports"
+    "description": "Plugin for pytest to generate allure xml reports"
   },
   {
     "version": "2.1.0",

--- a/run.py
+++ b/run.py
@@ -110,9 +110,8 @@ PLACEHOLDER_TOX = '''\
 [tox]
 
 [testenv]
-deps=pytest
-commands=
-    py.test --help
+deps = pytest
+commands = pytest --help
 '''
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 <div class="row">
 <h1>pytest Plugins Compatibility</h1>
 
-    <p>This page shows results of compatibility tests between <a href="http://pytest.org">py.test</a> plugins
+    <p>This page shows results of compatibility tests between <a href="https://pytest.org">pytest</a> plugins
        against different versions of the python interpreter.
     </p>
     <p>The plugins are listed and tested automatically from <a href="https://pypi.python.org/pypi">pypi</a>.
@@ -36,7 +36,7 @@
                 <th>Description</th>
                 {% for python_ver in python_versions %}
                 <th>{{ python_ver }}</th>
-                {% endfor %}                
+                {% endfor %}
             </tr>
         </thead>
         <tbody>
@@ -56,7 +56,7 @@
                     {% endif %}
                     </a>
                     </td>
-                {% endfor %}                
+                {% endfor %}
             </tr>
             {% endfor %}
         </tbody>

--- a/templates/status_help.html
+++ b/templates/status_help.html
@@ -11,7 +11,7 @@ of the plugin requested in the URL.</p>
 <p>You must pass the following parameters to this query:</p>
 <ul>
     <li>
-        <b>py</b>: python version as used in <a href="http://tox.org">tox</a>, for instance "py33" or "py22".
+        <b>py</b>: python version as used in <a href="https://tox.readthedocs.io">tox</a>, for instance "py33" or "py27".
     </li>
     <li>
         <b>pytest</b>: pytest version, for instance "2.3.5" or "2.4.2".


### PR DESCRIPTION
Some minor problems I noticed:

* some leftover py.test occurrences
* wrong url for tox docs
* pytest docs link was still http