### PR TITLE
Change DB to SQLAlchemy in the backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-services:
-  - mongodb
 install:
   - pip install -r dev-requirements.txt -U pytest==$PYTEST_VERSION
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,13 +1,13 @@
 asks
 attrs
 colorama
-dnspython
 distlib >= 0.2.8
 Flask
 gunicorn >= 19.5
 packaging
-pymongo >= 3
+psycopg2
 requests >= 1.3.0
+sqlalchemy
 tox
 trio
 wimpy >= 0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,27 +15,26 @@ chardet==3.0.4            # via requests
 click==7.1.2              # via flask
 colorama==0.4.3           # via -r requirements.in, tox
 distlib==0.3.1            # via -r requirements.in, virtualenv
-dnspython==2.0.0          # via -r requirements.in
 filelock==3.0.12          # via tox, virtualenv
 flask==1.1.2              # via -r requirements.in
 gunicorn==20.0.4          # via -r requirements.in
 h11==0.10.0               # via asks
 idna==2.10                # via anyio, requests, trio
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.2            # via flask
 markupsafe==1.1.1         # via jinja2
 outcome==1.0.1            # via trio
 packaging==20.4           # via -r requirements.in, tox
 pluggy==0.13.1            # via tox
+psycopg2==2.8.5           # via -r requirements.in
 py==1.9.0                 # via tox
 pycparser==2.20           # via cffi
-pymongo==3.11.0           # via -r requirements.in
 pyparsing==2.4.7          # via packaging
 requests==2.24.0          # via -r requirements.in
 six==1.15.0               # via packaging, tox, virtualenv
 sniffio==1.1.0            # via anyio, trio
 sortedcontainers==2.2.2   # via trio
+sqlalchemy==1.3.19        # via -r requirements.in
 toml==0.10.1              # via tox
 tox==3.19.0               # via -r requirements.in
 trio==0.16.0              # via -r requirements.in
@@ -43,7 +42,6 @@ urllib3==1.25.10          # via requests
 virtualenv==20.0.31       # via tox
 werkzeug==1.0.1           # via flask
 wimpy==0.6                # via -r requirements.in
-zipp==3.1.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,8 +13,7 @@
             https://github.com/pytest-dev/plugincompat</a>.
     </p>
 
-    <p>PyPI projects that declare the <b>Framework :: Pytest</b> classifier or whose
-        name starts with <b>pytest-</b> are considered plugins.</p>
+    <p>PyPI projects that match "pytest-*" are considered plugins.</p>
 
     <p>
         <strong>Note:</strong> although some may appear as "broken" keep in mind


### PR DESCRIPTION
Unfortunately the mLab free tier is no longer available, and for some reason the Atlas MongoDB is too slow for us to use (getting all results of over 750 plugins takes more than 150s). Instead of spending more time investigating, decided to move to PostgreSQL.

This actually simplified testing because we no longer need to mock the `PlugStorage` abstraction (we can use a in-memory sqlite).