### PR TITLE
Rate limit requests to PyPI due to recent PyPI changes

### DIFF
--- a/update_index.py
+++ b/update_index.py
@@ -56,7 +56,7 @@ class RateLimitedServerProxy:
                     return_value = request_method()
                 fetched_releases = True
             except Fault as fault:
-                # If PyPI times us out, sleep and try again depending on the error message received
+                # If PyPI errors due to too many requests, sleep and try again depending on the error message received
                 unandled_exception = True
 
                 # The fault message is of form:
@@ -67,6 +67,8 @@ class RateLimitedServerProxy:
                     time.sleep(sleep_amt)
                     unhandled_exception = False
 
+                # The fault message is of form:
+                #   The action could not be performed because there were too many requests by the client.
                 too_many_requests_regex_match = re.search('^.+The action could not be performed because there were too many requests by the client.$', fault.faultString)
                 if too_many_requests_regex_match is not None:
                     time.sleep(60)


### PR DESCRIPTION
Rate limit how we send requests to PyPI in `update_index.py` due to https://github.com/pypa/warehouse/issues/8753.

We should ideally move to https://wiki.python.org/moin/PyPIJSON, but this is a suitable intermediary. After this merges, I will open an issue to make the migration

I tested everything locally, and was able to successfully update my index.json with these code changes

Closes https://github.com/pytest-dev/plugincompat/issues/58