### PR TITLE
Rate limit PyPI requests in run.py to comply with recent PyPI changes

### DIFF
--- a/pypi_rpc_client/proxy.py
+++ b/pypi_rpc_client/proxy.py
@@ -1,0 +1,61 @@
+import re
+import time
+from xmlrpc.client import Fault
+from xmlrpc.client import ServerProxy
+
+
+class RateLimitedProxy:
+    """
+    RateLimitedProxy is a wrapper around the xmlrpc.client.ServerProxy module used to make requests to PyPI.
+    The methods are identical to the xmlrpc.client.ServerProxy methods except for the fact that requests are throttled
+    based on the return messages from PyPI. The need for rate limiting is due to the issue described in
+    https://github.com/pypa/warehouse/issues/8753.
+
+    Note that this class should be deprecated with a migration to PyPIJSON: https://wiki.python.org/moin/PyPIJSON
+    """
+
+    def __init__(self, uri):
+        self._server_proxy = ServerProxy(uri)
+
+    def browse(self, classifiers):
+        return self._rate_limit_request(self._server_proxy.browse, classifiers)
+
+    def list_packages(self):
+        return self._rate_limit_request(self._server_proxy.list_packages)
+
+    def package_releases(self, package_name):
+        return self._rate_limit_request(self._server_proxy.package_releases, package_name)
+
+    def release_data(self, name, version):
+        return self._rate_limit_request(self._server_proxy.release_data, name, version)
+
+    def release_urls(self, name, version):
+        return self._rate_limit_request(self._server_proxy.release_urls, name, version)
+
+    def _rate_limit_request(self, request_method, *args):
+        while True:
+            try:
+                return request_method(*args)
+            except Fault as fault:
+                # If PyPI errors due to too many requests, sleep and try again depending on the error message received
+                # The fault message is of form:
+                #   The action could not be performed because there were too many requests by the client. Limit may reset in 1 seconds.
+                limit_reset_regex_match = re.search(
+                    r"^.+Limit may reset in (\d+) seconds\.$", fault.faultString
+                )
+                if limit_reset_regex_match is not None:
+                    sleep_amt = int(limit_reset_regex_match.group(1))
+                    time.sleep(sleep_amt)
+                    continue
+
+                # The fault message is of form:
+                #   The action could not be performed because there were too many requests by the client.
+                too_many_requests_regex_match = re.search(
+                    "^.+The action could not be performed because there were too many requests by the client.$",
+                    fault.faultString,
+                )
+                if too_many_requests_regex_match is not None:
+                    time.sleep(60)
+                    continue
+
+                raise

--- a/run.py
+++ b/run.py
@@ -31,7 +31,6 @@ from io import StringIO
 from tempfile import mkdtemp
 from typing import List
 from typing import Optional
-from xmlrpc.client import ServerProxy
 from zipfile import ZipFile
 
 import asks
@@ -45,6 +44,7 @@ from wimpy.util import strip_suffix
 from wimpy.util import working_directory
 
 import update_index
+from pypi_rpc_client.proxy import RateLimitedProxy
 
 
 async def download_package(client, session, name, version):
@@ -264,7 +264,7 @@ async def run_package(session, tox_env, pytest_version, name, version, descripti
         except Exception:
             pass
 
-    client = ServerProxy("https://pypi.org/pypi")
+    client = RateLimitedProxy("https://pypi.org/pypi")
     basename = await download_package(client, session, name, version)
     if basename is None:
         status_code, output = 1, "No source or compatible distribution found"


### PR DESCRIPTION
`run.py` suffers from the same issues as `update_index.py`, so I am extending https://github.com/pytest-dev/plugincompat/pull/59 to fix this issue. You can see it happening on travis runs on master ( e.g.: https://travis-ci.org/github/pytest-dev/plugincompat/jobs/744924574 ). 

I ran `run.py` locally and was unable to get it to error like it did in the travis link above.