### PR TITLE
add shellcheck to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
     hooks:
     -   id: pyupgrade
         args: [--py3-plus]
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.1.1
+    hooks:
+    -   id: shellcheck

--- a/heroku_update.bash
+++ b/heroku_update.bash
@@ -5,7 +5,7 @@ git config --global user.email pytestbot@gmail.com
 git clone https://github.com/pytest-dev/plugincompat.git
 
 echo "Updating..."
-cd plugincompat
+cd plugincompat || exit
 python update_index.py
 
 echo "Push..."
@@ -14,4 +14,4 @@ git commit -a -m "Updating index (from heroku)"
 #   https://github.com/settings/tokens
 # and made available to this script as a config var setting in Heroku:
 #   https://dashboard.heroku.com/apps/plugincompat/settings
-git push https://$GITHUB_TOKEN:x-oauth-basic@github.com/pytest-dev/plugincompat.git master
+git push "https://$GITHUB_TOKEN:x-oauth-basic@github.com/pytest-dev/plugincompat.git" master


### PR DESCRIPTION
Adding in [shellcheck](https://github.com/koalaman/shellcheck) to the pre-commit hooks so we can lint our shell scripts.

The changes made were due to shell check rules [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164) and [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) respectively.