### PR TITLE
README should not mention Framework :: Pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ versions, displaying them in a web page for quick consulting.
 
 See test results are at http://plugincompat.herokuapp.com.
 
-PyPI projects that declare the `Framework :: Pytest` classifier or whose
+PyPI projects whose
 name starts with `pytest-` are considered plugins.
 
 [![ci](http://img.shields.io/travis/pytest-dev/plugincompat.svg)](https://travis-ci.org/pytest-dev/plugincompat)


### PR DESCRIPTION
until #53 is resolved.

See #55